### PR TITLE
use dependency mgmt instead of explicit versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,32 +24,23 @@ repositories {
     mavenCentral()
 }
 
+
+ext['snakeyaml.version'] = '2.0'
 dependencies {
-    implementation "org.springframework.boot:spring-boot-starter-web:3.1.4"
-    implementation "org.springframework.boot:spring-boot-starter-actuator:3.1.4"
-    implementation "org.springframework.boot:spring-boot-starter-validation:3.1.4"
-    implementation "io.micrometer:micrometer-registry-influx:1.9.0"
+    implementation "org.springframework.boot:spring-boot-starter-web"
+    implementation "org.springframework.boot:spring-boot-starter-actuator"
+    implementation "org.springframework.boot:spring-boot-starter-validation"
+    implementation "io.micrometer:micrometer-registry-influx"
     implementation "org.javapos:javapos-config-loader:2.2.0"
     implementation "org.javapos:javapos:1.14.3"
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.14.0"
-    implementation "com.fasterxml.jackson.core:jackson-core:2.14.0"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.14.0"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.0"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.14.0"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0"
-    implementation "com.fasterxml.jackson.module:jackson-module-parameter-names:2.14.0"
-    implementation "jakarta.servlet:jakarta.servlet-api:6.0.0"
-    implementation "jakarta.validation:jakarta.validation-api:3.0.2"
-    implementation "jakarta.annotation:jakarta.annotation-api:2.1.1"
 
     implementation "net.logstash.logback:logstash-logback-encoder:6.4"
-    implementation "org.yaml:snakeyaml:2.0"
 
-    implementation "org.springframework.boot:spring-boot-starter-cache:3.1.4"
-    implementation "com.github.ben-manes.caffeine:caffeine:2.9.3"
+    implementation "org.springframework.boot:spring-boot-starter-cache"
+    implementation "com.github.ben-manes.caffeine:caffeine"
     implementation "io.github.classgraph:classgraph:4.8.147"
-    testImplementation "org.springframework.boot:spring-boot-starter-test:3.1.4"
+    testImplementation "org.springframework.boot:spring-boot-starter-test"
 }
 
 tasks.withType(JavaExec){
@@ -85,7 +76,6 @@ task copyRuntimeJars(type: Copy) {
     into "$buildDir/libs"
 }
 
-ext['log4j2.version'] = '2.17.1'
 
 shadowJar{
     archiveClassifier.set("")


### PR DESCRIPTION
Description of changes:
remove explicit versions from build file to let spring plugin take over and when that is not enough, use the recommend way of overriding spring dependencies `ext['snakeyaml.version'] = '2.0'`

Description of testing:
Please make sure the following changes have been made before creating a pull request.

Update `Description`
- [ ] `Change tested on actual device`
- [ ] `Changes tested for simulator`
- [ ] `Existing device functionality is working fine`
- [x] `Unit Tests Written for Code Changes, and Verified that Coverage is 100% for Modified Files(with the exception of ATM devices)`
